### PR TITLE
Fixing DBAL-related problems

### DIFF
--- a/TaoDbConfig.php
+++ b/TaoDbConfig.php
@@ -35,14 +35,14 @@ class TaoDbConfig extends DataType
 
         require_once $path;
 
+        //this was changed after switch to DBAL - with this code, DB backup phing task would be usable on both PDO and DBAL
         if ( ! $this->params) {
             $persistence   = \common_persistence_Manager::getPersistence('default');
-            $schemaManager = $persistence->getDriver()->getSchemaManager();
 
-            $reflectionMethod = (new ReflectionMethod(get_class($schemaManager), 'getDriver'));
-            $reflectionMethod->setAccessible(true);
-            $this->params = $reflectionMethod->invoke($schemaManager)->getParams();
+            $refl = (new ReflectionMethod(get_class($persistence), 'getParams'));
+            $refl->setAccessible(true);
 
+            $this->params = $refl->invoke($persistence);
         }
 
 


### PR DESCRIPTION
Re-written part of code, so now db-config-related tasks would be usable on both PDO and DBAL.

### A bit of background.

On previous code we had situations in which after switch to DBAL, and when `tao.fresh.install` is set to `false` in `build.properties` build was failing. It was failing because in DBAL we don't have `getDriver` method inside SchemaManager.